### PR TITLE
低配置设备延迟初始化相机防闪退

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ SDK支持Android 5+，建议设备配置 CPU为八核64位2.4GHz以上  摄像�
    Demo 以main主工程 --> faceAiLib 的方式演示，熟悉本SDK 接入Demo 后可以先Copy faceAiLib到你主工程先跑起来
    再根据业务情况修改完善。  
    熟悉后大约2小时就能集成成功，丰富产品功能同时可大大降低公司研发投入实现降本增效。  
-
    
+      
 
 ![让子弹飞剧照-这是你吗？](https://github.com/user-attachments/assets/dfe7156f-d458-4294-aa25-70aa0216c760)

--- a/faceAILib/build.gradle
+++ b/faceAILib/build.gradle
@@ -37,7 +37,7 @@ android {
 // GitHub 无法访问，挂梯子也无效 ？参考 https://github.com/maxiaof/github-hosts
 dependencies {
     // 人脸识别 试用版本请升级到1.8.60 以上版本。https://github.com/AnyLifeZLB/FaceVerificationSDK
-    implementation 'io.github.anylifezlb:FaceAISDK:1.8.86.camera' //新的依赖方式改了后缀
+    implementation 'io.github.anylifezlb:FaceAISDK:1.8.90.alpha1' //新的依赖方式改了后缀
 
     //implementation 'io.github.anylifezlb:FaceRecognition:1.8.90' //老的 FaceRecognition
 

--- a/faceAILib/src/main/res/values-zh-rCN/strings.xml
+++ b/faceAILib/src/main/res/values-zh-rCN/strings.xml
@@ -47,7 +47,7 @@
     <string name="stop_verify_tips">停止识别,识别过程请保持人脸在画面中 </string>
 
     <!--Navi activity-->
-    <string name="binocular_camera_demo">双目摄像头演示</string>
+    <string name="binocular_camera_demo">USB双目摄像头(UVC协议)演示</string>
     <string name="face_verify_1vs1">1:1人脸识别 </string>
     <string name="add_face_image">人脸底图录入</string>
     <string name="only_motion_liveness_detection">仅人脸活体检测</string>


### PR DESCRIPTION
部分低配置设备摄像头闪退。先杀死其他可能占用摄像头应用